### PR TITLE
Add concatenation of multiple sequencing runs 

### DIFF
--- a/conf/metagear/common.config
+++ b/conf/metagear/common.config
@@ -22,6 +22,13 @@ process {
         ]
     }
 
+    withName: CONCATENATE_READS {
+
+        publishDir = [
+            enabled: false,
+        ]
+    }
+
     withName: MULTIQC {
 
         publishDir = [

--- a/modules/local/metagear/utils/concatenate_reads.nf
+++ b/modules/local/metagear/utils/concatenate_reads.nf
@@ -1,0 +1,31 @@
+process CONCATENATE_READS {
+    tag "$meta.id"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path({["${meta.id}_concatenated_1.fastq.gz", "${meta.id}_concatenated_2.fastq.gz"]})
+
+    script:
+    def r1_reads = reads.findAll { it.name ==~ /.*_1\.(fq|fastq)(\.gz)?$/ }
+    def r2_reads = reads.findAll { it.name ==~ /.*_2\.(fq|fastq)(\.gz)?$/ }
+
+    def r1_out = "${meta.id}_concatenated_1.fastq.gz"
+    def r2_out = "${meta.id}_concatenated_2.fastq.gz"
+
+    // If there is more than 1 read file per id concatenate, otherwise just link to the file.
+    def r1_cmd = r1_reads.size() > 1
+        ? "cat ${r1_reads.join(' ')} > $r1_out"
+        : "ln -s ${r1_reads[0]} $r1_out"
+
+    def r2_cmd = r2_reads.size() > 1
+        ? "cat ${r2_reads.join(' ')} > $r2_out"
+        : "ln -s ${r2_reads[0]} $r2_out"
+
+    """
+    set -e
+    $r1_cmd
+    $r2_cmd
+    """
+}

--- a/modules/local/metagear/utils/concatenate_reads.nf
+++ b/modules/local/metagear/utils/concatenate_reads.nf
@@ -5,23 +5,26 @@ process CONCATENATE_READS {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path({["${meta.id}_concatenated_1.fastq.gz", "${meta.id}_concatenated_2.fastq.gz"]})
+    tuple val(meta), path({"${meta.id}_concatenated_[12].fastq.gz"})
 
     script:
-    def r1_reads = reads.findAll { it.name ==~ /.*_1\.(fq|fastq)(\.gz)?$/ }
-    def r2_reads = reads.findAll { it.name ==~ /.*_2\.(fq|fastq)(\.gz)?$/ }
+    def r1_reads = reads.findAll { it.name ==~ /.*_(1|R1_\d+)\.(fq|fastq)(\.gz)?$/ }
+    def r2_reads = reads.findAll { it.name ==~ /.*_(2|R2_\d+)\.(fq|fastq)(\.gz)?$/ }
 
     def r1_out = "${meta.id}_concatenated_1.fastq.gz"
-    def r2_out = "${meta.id}_concatenated_2.fastq.gz"
-
-    // If there is more than 1 read file per id concatenate, otherwise just link to the file.
     def r1_cmd = r1_reads.size() > 1
         ? "cat ${r1_reads.join(' ')} > $r1_out"
         : "ln -s ${r1_reads[0]} $r1_out"
 
-    def r2_cmd = r2_reads.size() > 1
-        ? "cat ${r2_reads.join(' ')} > $r2_out"
-        : "ln -s ${r2_reads[0]} $r2_out"
+    // Prepare r2 only if available
+    def r2_cmd = ""
+    def r2_out = ""
+    if (r2_reads) {
+        r2_out = "${meta.id}_concatenated_2.fastq.gz"
+        r2_cmd = r2_reads.size() > 1
+            ? "cat ${r2_reads.join(' ')} > $r2_out"
+            : "ln -s ${r2_reads[0]} $r2_out"
+    }
 
     """
     set -e

--- a/subworkflows/local/common/quality_control.nf
+++ b/subworkflows/local/common/quality_control.nf
@@ -1,6 +1,7 @@
 /* --- Perform quality control on reads --- */
 
 include { INPUT_CHECK } from "$projectDir/subworkflows/local/common/input_check"
+include { CONCATENATE_READS } from "$projectDir/modules/local/metagear/utils/concatenate_reads"
 
 include { FASTQC as FASTQC_RAW; FASTQC as FASTQC_CLEAN} from "$projectDir/modules/nf-core/fastqc/main"
 include { TRIMGALORE } from "$projectDir/modules/nf-core/trimgalore/main"
@@ -19,8 +20,10 @@ workflow QUALITY_CONTROL_INIT {
         def kneaddata_dbs = params.kneaddata_refdb.collect { file(it) }
         kneaddata_refdb = Channel.value(kneaddata_dbs)
 
+        CONCATENATE_READS ( INPUT_CHECK.out.validated_input )
+
     emit:
-        validated_input = INPUT_CHECK.out.validated_input
+        validated_input = CONCATENATE_READS.out
         kneaddata_refdb = kneaddata_refdb
         versions = INPUT_CHECK.out.versions
 


### PR DESCRIPTION
Adds concatenation of multiple read files for a single sample, fixing #16 

A new process is added concatenating reads if there are multiple files per sample id. Otherwise it just links to the single file. The concatenated files are not published in the results.

I tested it with SE and PE inputs. And filename endings reads_1.fastq/fastq.gz/fq/fq.gz and reads_2.fastq.gz as well as with reads_R1_001.fastq.gz etc.  If read files are not named after these two conventions it will not work.