### PR TITLE
Add workflow name to pipeline_info

### DIFF
--- a/conf/metagear/common.config
+++ b/conf/metagear/common.config
@@ -7,7 +7,7 @@ process {
     withName: SAMPLESHEET_CHECK {
 
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
+            path: { "${params.outdir}/${params.workflow}_pipeline_info" },
         ]
     }
 
@@ -25,7 +25,7 @@ process {
     withName: MULTIQC {
 
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
+            path: { "${params.outdir}/${params.workflow}_pipeline_info" },
         ]
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -212,19 +212,19 @@ nextflow.enable.configProcessNamesValidation = false
 
 timeline {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
 }
 report {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_report_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_report_${params.trace_report_suffix}.html"
 }
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
 }
 
 manifest {

--- a/subworkflows/local/common/summary.nf
+++ b/subworkflows/local/common/summary.nf
@@ -30,7 +30,7 @@ workflow SUMMARY {
         //
         softwareVersionsToYAML(ch_versions)
             .collectFile(
-                storeDir: "${params.outdir}/pipeline_info",
+                storeDir: "${params.outdir}/${params.workflow}_pipeline_info",
                 name:  ''  + 'pipeline_software_' +  'mqc_'  + 'versions.yml',
                 sort: true,
                 newLine: true

--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -77,7 +77,7 @@ def dumpParametersToJSON(outdir) {
     def jsonStr   = groovy.json.JsonOutput.toJson(params)
     temp_pf.text  = groovy.json.JsonOutput.prettyPrint(jsonStr)
 
-    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/pipeline_info/params_${timestamp}.json")
+    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/${params.workflow}_pipeline_info/params_${timestamp}.json")
     temp_pf.delete()
 }
 


### PR DESCRIPTION
I appended the workflow name to results/pipeline_info (-> results/qc_dna_pipeline_info when running qc_dna). 

This prevents the issue #18 and adds better overview when running multiple workflows in a single directory. 