### PR TITLE
Improve pipeline_info outputs

### DIFF
--- a/conf/metagear/common.config
+++ b/conf/metagear/common.config
@@ -7,8 +7,7 @@ process {
     withName: SAMPLESHEET_CHECK {
 
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
-            mode: "copy"
+            path: { "${params.outdir}/${params.workflow}_pipeline_info" },
         ]
     }
 
@@ -26,8 +25,7 @@ process {
     withName: MULTIQC {
 
         publishDir = [
-            path: { "${params.outdir}/pipeline_info" },
-            mode: "copy"
+            path: { "${params.outdir}/${params.workflow}_pipeline_info" },
         ]
     }
 

--- a/conf/metagear/common.config
+++ b/conf/metagear/common.config
@@ -1,5 +1,6 @@
 params {
     validate_params = false
+    workflow = "e2e"  // Default workflow name when not specified
 }
 
 process {
@@ -7,8 +8,9 @@ process {
     withName: SAMPLESHEET_CHECK {
 
         publishDir = [
-            path: { "${params.outdir}/${params.workflow}_pipeline_info" },
-            mode: "copy"
+            path: { "${params.outdir}/pipeline_info" },
+            mode: "copy",
+            saveAs: { filename -> "${params.workflow}_${filename}" }
         ]
     }
 
@@ -26,8 +28,9 @@ process {
     withName: MULTIQC {
 
         publishDir = [
-            path: { "${params.outdir}/${params.workflow}_pipeline_info" },
-            mode: "copy"
+            path: { "${params.outdir}/pipeline_info" },
+            mode: "copy",
+            saveAs: { filename -> "${params.workflow}_${filename}" }
         ]
     }
 

--- a/conf/metagear/common.config
+++ b/conf/metagear/common.config
@@ -8,6 +8,7 @@ process {
 
         publishDir = [
             path: { "${params.outdir}/${params.workflow}_pipeline_info" },
+            mode: "copy"
         ]
     }
 
@@ -26,6 +27,7 @@ process {
 
         publishDir = [
             path: { "${params.outdir}/${params.workflow}_pipeline_info" },
+            mode: "copy"
         ]
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -209,19 +209,19 @@ nextflow.enable.configProcessNamesValidation = false
 
 timeline {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
 }
 report {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_report_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_report_${params.trace_report_suffix}.html"
 }
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/${params.workflow}_pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
 }
 
 manifest {

--- a/nextflow.config
+++ b/nextflow.config
@@ -209,19 +209,19 @@ nextflow.enable.configProcessNamesValidation = false
 
 timeline {
     enabled = true
-    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/pipeline_info/${params.workflow}_execution_timeline_${params.trace_report_suffix}.html"
 }
 report {
     enabled = true
-    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_report_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/pipeline_info/${params.workflow}_execution_report_${params.trace_report_suffix}.html"
 }
 trace {
     enabled = true
-    file    = "${params.outdir}/${params.workflow}_pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
+    file    = "${params.outdir}/pipeline_info/${params.workflow}_execution_trace_${params.trace_report_suffix}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.outdir}/${params.workflow}_pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
+    file    = "${params.outdir}/pipeline_info/${params.workflow}_pipeline_dag_${params.trace_report_suffix}.html"
 }
 
 manifest {

--- a/subworkflows/local/common/summary.nf
+++ b/subworkflows/local/common/summary.nf
@@ -30,8 +30,8 @@ workflow SUMMARY {
         //
         softwareVersionsToYAML(ch_versions)
             .collectFile(
-                storeDir: "${params.outdir}/${params.workflow}_pipeline_info",
-                name:  ''  + 'pipeline_software_' +  'mqc_'  + 'versions.yml',
+                storeDir: "${params.outdir}/pipeline_info",
+                name:  "${params.workflow}_pipeline_software_mqc_versions.yml",
                 sort: true,
                 newLine: true
             ).set { ch_collated_versions }

--- a/subworkflows/local/common/summary.nf
+++ b/subworkflows/local/common/summary.nf
@@ -30,7 +30,7 @@ workflow SUMMARY {
         //
         softwareVersionsToYAML(ch_versions)
             .collectFile(
-                storeDir: "${params.outdir}/pipeline_info",
+                storeDir: "${params.outdir}/${params.workflow}_pipeline_info",
                 name:  ''  + 'pipeline_software_' +  'mqc_'  + 'versions.yml',
                 sort: true,
                 newLine: true

--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -77,7 +77,7 @@ def dumpParametersToJSON(outdir) {
     def jsonStr   = groovy.json.JsonOutput.toJson(params)
     temp_pf.text  = groovy.json.JsonOutput.prettyPrint(jsonStr)
 
-    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/pipeline_info/params_${timestamp}.json")
+    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/${params.workflow}_pipeline_info/params_${timestamp}.json")
     temp_pf.delete()
 }
 

--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -77,7 +77,7 @@ def dumpParametersToJSON(outdir) {
     def jsonStr   = groovy.json.JsonOutput.toJson(params)
     temp_pf.text  = groovy.json.JsonOutput.prettyPrint(jsonStr)
 
-    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/${params.workflow}_pipeline_info/params_${timestamp}.json")
+    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/pipeline_info/${params.workflow}_params_${timestamp}.json")
     temp_pf.delete()
 }
 


### PR DESCRIPTION
As per https://github.com/schirmer-lab/metagear-pipeline/issues/18:

The pipeline now outputs files prepended by the workflow executed to pipeline_info:
<img width="405" height="398" alt="image" src="https://github.com/user-attachments/assets/8bde4977-851c-49b1-9faf-e7f78fe1a011" />


Incorporating changes from: https://github.com/schirmer-lab/metagear-pipeline/pull/19